### PR TITLE
Documents/job stories update

### DIFF
--- a/reports/m2_spec.md
+++ b/reports/m2_spec.md
@@ -21,7 +21,7 @@
 | `deadline_pressure_level`         | Input         | `ui.input_checkbox_group()`| —         | #1, #2     |
 | `reset_btn`       | Input         | `ui.input_action_button()` | -                         | #1, #2, #3 |
 | `filtered_df`     | Reactive calc | `@reactive.calc`        | all inputs above             | #1, #2, #3 |
-| `_reset_filters`  | Reactive effect | `@reactive.effect` + `@reactive.event(input.reset_btn)`| `reset_btn` | #1, #2, #3 |
+| `_reset_filters`  | Reactive effect | `@reactive.effect` + `@reactive.event(input.reset_btn)`| `reset_btn`  | #1, #2, #3 |
 | `avg_burnout`     | Output        | `@render.text`                | `filtered_df`                | #1       |
 | `avg_productivity`| Output        |` @render.text`                | `filtered_df`                | #1, #3   |
 | `burnout_vs_median`   | Output    | `@render.text`                | `filtered_df`, baselines     | #1       |


### PR DESCRIPTION
Close #34 & #37 

Hi @ruthyankson and @GloriaYi! I just added sections **2.1 Updated Job Stories** and **2.2 Component Inventory** to our report.  I added a new input component so that we can incorporate a reset button that will reset all filters to the original value :)

We're still missing to update the comments on the updated job stories table, we can do this once the dashboard is functional so that we can justify how it has been implemented. Let me know if there are any additional changes you'd like me to make. 

Note: I added sections 2.3 and 2.4 but I copied and pasted them from the example given by Ilya, we still need to update them!