### PR TITLE
Feature/dashboard restructure

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -286,45 +286,54 @@ app_ui = ui.page_fluid(
         # ==================================================
         ui.nav_panel(
             "AI Explorer",
-            ui.div(
+            ui.layout_sidebar(
                 # -------------------------
-                # AI Explorer header and query input
+                # AI Explorer sidebar
                 # -------------------------
-                ui.h3("AI Explorer"),
-                ui.p("Use natural language to explore the filtered dataset."),
-                ui.input_text_area(
-                    "ai_query",
-                    "Ask a question about the data:",
-                    placeholder="Example: Show employees with high burnout risk and high AI usage",
-                    rows=4,
+                ui.sidebar(
+                    ui.h3("AI Explorer"),
+                    ui.p("Use natural language to explore the filtered dataset."),
+                    ui.input_text_area(
+                        "ai_query",
+                        "Ask a question about the data:",
+                        placeholder="Example: Show employees with high burnout risk and high AI usage",
+                        rows=6,
+                    ),
+                    ui.br(),
+                    ui.input_action_button("run_ai_query", "Run query"),
+                    width=320,
                 ),
-                ui.br(),
-                ui.input_action_button("run_ai_query", "Run query"),
-                ui.br(),
                 # -------------------------
-                # AI Explorer KPI row
+                # AI Explorer main content
                 # -------------------------
-                ui.layout_columns(
-                    ui.output_ui("ai_count_box"),
-                    ui.output_ui("ai_burnout_box"),
-                    ui.output_ui("ai_productivity_box"),
-                    ui.output_ui("ai_high_burnout_box"),
-                    col_widths=(3, 3, 3, 3),
-                    class_="kpi-grid",
+                ui.div(
+                    # -------------------------
+                    # AI Explorer KPI row
+                    # -------------------------
+                    ui.layout_columns(
+                        ui.output_ui("ai_count_box"),
+                        ui.output_ui("ai_burnout_box"),
+                        ui.output_ui("ai_productivity_box"),
+                        ui.output_ui("ai_high_burnout_box"),
+                        col_widths=(3, 3, 3, 3),
+                        class_="kpi-grid",
+                    ),
+                    ui.br(),
+                    # -------------------------
+                    # AI Explorer table preview
+                    # -------------------------
+                    ui.card(
+                        ui.card_header(
+                            "Preview of AI-filtered data",
+                            ui.download_button(
+                                "download_ai_data",
+                                "Download AI-filtered data",
+                            ),
+                            class_="d-flex justify-content-between align-items-center",
+                        ),
+                        ui.output_data_frame("ai_table"),
+                    ),
                 ),
-                ui.br(),
-                # -------------------------
-                # AI Explorer table preview
-                # -------------------------
-                ui.card(
-                    ui.card_header("Preview of AI-filtered data"),
-                    ui.output_data_frame("ai_table"),
-                ),
-                ui.br(),
-                # -------------------------
-                # AI Explorer data download
-                # -------------------------
-                ui.download_button("download_ai_data", "Download AI-filtered data"),
             ),
         ),
     ),


### PR DESCRIPTION
- Refactored the AI Explorer tab layout to use a sidebar structure similar to the main dashboard.
- Converted the query input area into a chat-style sidebar using ui.layout_sidebar.
- Replaced the previous AI Explorer plots with four KPI cards summarizing the AI-filtered results (_Employees Found, Median Burnout Risk, Median Productivity, High Burnout %_).
- Positioned the KPIs above the filtered data table to provide a quick summary of query outputs.
- Removed unused AI Explorer visualizations to simplify the tab and focus on query-based exploration.